### PR TITLE
Display index items on a row

### DIFF
--- a/app/views/shared/_item.html.erb
+++ b/app/views/shared/_item.html.erb
@@ -1,0 +1,9 @@
+<div id="item_<%= item.id %>" class="thumbnail">
+  <%= link_to item_path(item) do %>
+    <img src=<%= item.image_url %> alt=<%= item.title %>>
+    <div class="caption">
+      <h3><%= item.title %></h3>
+    </div>
+  <% end %>
+  <p><%= number_to_currency(item.price_in_dollars) %><%= button_to "Add to cart", carts_path(item_id: item.id), class:"btn btn-info add_to_cart" %></p>
+</div>

--- a/app/views/shared/_items.html.erb
+++ b/app/views/shared/_items.html.erb
@@ -1,13 +1,15 @@
-<% @items.each do |item| %>
-  <div class="col-sm-6 col-md-4">
-    <div id="item_<%= item.id %>" class="thumbnail">
-      <%= link_to item_path(item) do %>
-        <img src=<%= item.image_url %> alt=<%= item.title %>>
-        <div class="caption">
-          <h3><%= item.title %></h3>
+<% @items.each_slice(4) do |four_items| %>
+  <div class="row">
+    <% four_items.each_slice(2) do |two_items| %>
+      <div class="col-md-6">
+        <div class="row">
+          <% two_items.each do |item| %>
+            <div class="col-sm-6">
+              <%= render partial: 'shared/item', locals: {item: item} %>
+            </div>
+          <% end %>
         </div>
-      <% end %>
-    <p><%= number_to_currency(item.price_in_dollars) %><%= button_to "Add to cart", carts_path(item_id: item.id), class:"btn btn-info add_to_cart" %></p>
-    </div>
+      </div>
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
@CPowell23 @lucyconklin @Robbie-Smith, Soooo, the goal of this code is to align the items on one row - and prevent the odd sort of breakage/wrapping/misalignment that was happening when images of different size were wrapping.

My first thought was to group the items in rows of four (note the `each_slice(4)`).  That way, when the row would wrap, it would go from 1 row of 4 to 2 rows of 2.  Great success!

Until the smaller rows of 2 were showing the same breakage/wrapping/misalignment that caused me to dive into this effort in the first place (whamp, whamp).  Soooo, I took the rows of four and broke them into rows of 2 (note the `each_slice(2)`).

Now, the rows of 4 break cleanly into rows of 2 which stack into columns of 1 as you narrow down the screen.  

This is not perfect.  I'm not a huge fan of the way the break points are working and would love some help adjusting the behavior (basically, keep more items on the rows for longer - I think the images get too big too fast as you decrease the screen width).  Grab the side of your screen on the items index, and I think you'll see what I mean.

In closing, this feels like a decent start, and halp!

As a sidenote - it was too much of a mind... bender to look at all the HTML for the rows AND the rendering the item, so I put the solo item into its own partial.